### PR TITLE
✨ Feat: 로그아웃, 탈퇴 시 모든 zustand 스토어 초기화

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-54d0af47'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.2sfn9rp6vf"
+    "revision": "0.gfv08nvjo0o"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,6 +1,9 @@
 import { create } from "zustand";
 import apiClient from "@utils/apiClient";
 import type { UserInfo } from "@types";
+import { useHistoryStore } from "@stores/historyStore";
+import { useScanResultStore } from "@stores/scanResultStore";
+import { useUserDistrictStore } from "@stores/userDistrictStore";
 
 type AuthStatus = "loading" | "member" | "guest";
 
@@ -62,6 +65,9 @@ const useAuthStore = create<AuthStore>((set) => ({
         await apiClient.post("/api/v1/auth/logout");
       } finally {
         set({ status: "guest", info: null });
+        useHistoryStore.getState().clearHistory();
+        useScanResultStore.getState().clearAllResults();
+        useUserDistrictStore.getState().actions.clearDistricts();
       }
     },
 
@@ -70,6 +76,9 @@ const useAuthStore = create<AuthStore>((set) => ({
         await apiClient.delete("/api/v1/users/me");
       } finally {
         set({ status: "guest", info: null });
+        useHistoryStore.getState().clearHistory();
+        useScanResultStore.getState().clearAllResults();
+        useUserDistrictStore.getState().actions.clearDistricts();
       }
     },
   },

--- a/src/stores/historyStore.ts
+++ b/src/stores/historyStore.ts
@@ -5,6 +5,7 @@ interface HistoryState {
   historyItems: HistoryItem[];
   setHistoryItems: (items: ApiTrashDetail[]) => void;
   deleteHistoryItems: (idsToDelete: number[]) => void;
+  clearHistory: () => void;
 }
 
 export const useHistoryStore = create<HistoryState>((set) => ({
@@ -25,4 +26,6 @@ export const useHistoryStore = create<HistoryState>((set) => ({
         (item) => !idsToDelete.includes(item.id)
       ),
     })),
+
+  clearHistory: () => set({ historyItems: [] }),
 }));

--- a/src/stores/scanResultStore.ts
+++ b/src/stores/scanResultStore.ts
@@ -9,6 +9,7 @@ interface ScanResultState {
   fetchResultById: (id: number) => Promise<void>;
   clearCurrentResult: () => void;
   updateCurrentResult: (newResult: ApiTrashDetail) => void;
+  clearAllResults: () => void;
 }
 
 export const useScanResultStore = create<ScanResultState>((set, get) => ({
@@ -54,4 +55,6 @@ export const useScanResultStore = create<ScanResultState>((set, get) => ({
       resultsById: { ...state.resultsById, [newResult.id]: newResult },
     }));
   },
+
+  clearAllResults: () => set({ resultsById: {}, currentResult: null }),
 }));

--- a/src/stores/userDistrictStore.ts
+++ b/src/stores/userDistrictStore.ts
@@ -15,20 +15,15 @@ interface UserDistrictState {
   actions: {
     fetchDistricts: () => Promise<void>;
     changeDefault: (userDistrictId: number) => Promise<void>;
-
-    // 현재 위치 설정
     setCurrentDistrict: () => Promise<Location | null>;
-
-    // 자치구 설정
     setDistrict: (district: Location) => Promise<{
       label: string;
       districtId: string; // bcode
       sigCode: string;
     } | null>;
-
-    // 자치구 삭제
     removeDistrict: (userDistrictId: number) => Promise<void>;
     setGuestDistrict: (district: Location | null) => void;
+    clearDistricts: () => void;
   };
 }
 
@@ -112,7 +107,7 @@ async function reverseFromCoord(
   };
 }
 
-const useUserDistrictStore = create<UserDistrictState>((set) => ({
+export const useUserDistrictStore = create<UserDistrictState>((set) => ({
   districts: [],
   defaultDistrict: null,
 


### PR DESCRIPTION
## 📋 작업 내용
로그아웃, 탈퇴 시 모든 zustand 스토어 초기화

## 🎯 관련 이슈
- closes #80 

## 📝 변경 사항
- [x] 로그아웃, 탈퇴 시 모든 zustand 스토어 초기화

## 📸스크린샷 (선택)

## ✅ PR Checklist

<!--- PR이 다음 요구 사항을 충족하는지 확인하세요.-->
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
